### PR TITLE
Revisión: 3 - Restricción de pagos por país

### DIFF
--- a/controllers/front/redirect.php
+++ b/controllers/front/redirect.php
@@ -138,7 +138,7 @@ class MoneiRedirectModuleFrontController extends ModuleFrontController
 
                 if ($response->getNextAction()->getMustRedirect()) {
                     $redirectURL = $response->getNextAction()->getRedirectUrl();
-                    if ($response->getStatusCode() === MoneiPaymentStatus::FAILED) {
+                    if ($response->getStatus() === MoneiPaymentStatus::FAILED) {
                         $redirectURL .= '&message=' . $response->getStatusMessage();
                     }
 

--- a/src/Monei/Model/MoneiPaymentMethods.php
+++ b/src/Monei/Model/MoneiPaymentMethods.php
@@ -1,6 +1,4 @@
 <?php
-
-
 namespace Monei\Model;
 
 class MoneiPaymentMethods
@@ -35,5 +33,41 @@ class MoneiPaymentMethods
             self::KLARNA,
             self::MULTIBANCO,
         ];
+    }
+
+    private static function isPaymentMethodAllowedByIsoCode(string $paymentMethod, string $isoCode): bool
+    {
+        switch ($paymentMethod) {
+            case self::BIZUM:
+                return $isoCode === 'ES';
+            case self::COFIDIS:
+                return $isoCode === 'ES';
+            case self::MULTIBANCO:
+                return $isoCode === 'PT';
+            case self::KLARNA:
+                return in_array($isoCode, ['AT', 'BE', 'CH', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'IT', 'NL', 'NO', 'SE']);
+            default:
+                return true;
+        }
+    }
+
+    public static function isBizumAvailable(string $isoCode): bool
+    {
+        return self::isPaymentMethodAllowedByIsoCode(self::BIZUM, $isoCode);
+    }
+
+    public static function isMultibancoAvailable(string $isoCode): bool
+    {
+        return self::isPaymentMethodAllowedByIsoCode(self::MULTIBANCO, $isoCode);
+    }
+
+    public static function isKlarnaAvailable(string $isoCode): bool
+    {
+        return self::isPaymentMethodAllowedByIsoCode(self::KLARNA, $isoCode);
+    }
+
+    public static function isCofidisAvailable(string $isoCode): bool
+    {
+        return self::isPaymentMethodAllowedByIsoCode(self::COFIDIS, $isoCode);
     }
 }


### PR DESCRIPTION
- Se ha eliminado la imagen asociada al método de pago "tarjeta" debido a que las marcas varían según la cuenta, lo que imposibilita la representación mediante una única imagen.
- Se ha introducido una nueva característica que permite mostrar métodos de pago específicos basados en el país de facturación del cliente, mejorando así la relevancia y precisión del proceso de checkout.
- Se ha solucionado un problema que impedía la correcta visualización de mensajes de error en caso de fallos en el proceso.