### PR TITLE
Revision: 28 - fix issue #41 and #36

### DIFF
--- a/monei.php
+++ b/monei.php
@@ -1016,7 +1016,7 @@ class Monei extends PaymentModule
         return $billingData;
     }
 
-    public function createPayment(bool $tokenizeCard = false, int $moneiCardId = 0): MoneiPayment
+    public function createPayment(bool $tokenizeCard = false, int $moneiCardId = 0)
     {
         $moneiClient = new MoneiClient(
             Configuration::get('MONEI_API_KEY'),
@@ -1542,6 +1542,7 @@ class Monei extends PaymentModule
 
         // Google
         if (Configuration::get('MONEI_ALLOW_GOOGLE') &&
+            !PsTools::isSafariBrowser() &&
             $moneiPaymentMethod->isPaymentMethodAllowed(MoneiPaymentMethods::GOOGLE, $currencyIsoCode)
         ) {
             $paymentOptionList['googlePay'] = [

--- a/monei.php
+++ b/monei.php
@@ -12,7 +12,6 @@ use Monei\Model\MoneiCustomer;
 use Monei\Model\MoneiPayment;
 use Monei\Model\MoneiPaymentMethods;
 use Monei\Model\MoneiPaymentStatus;
-use Monei\Model\MoneiShippingDetails;
 use Monei\MoneiClient;
 use Monei\Traits\ValidationHelpers;
 
@@ -931,81 +930,126 @@ class Monei extends PaymentModule
         );
     }
 
-    public function createPaymentObject(): MoneiPayment
+    public function getCartAmount()
     {
         $cart = $this->context->cart;
-        $link = $this->context->link;
-        $customer = $this->context->customer;
-        $currency = new Currency($cart->id_currency);
-
-        $langId = (int) $this->context->language->id;
-
-        $currencyDecimals = is_array($currency) ? (int) $currency['decimals'] : (int) $currency->decimals;
-        $decimals = $currencyDecimals * _PS_PRICE_DISPLAY_PRECISION_; // _PS_PRICE_DISPLAY_PRECISION_ deprec 1.7.7 TODO
 
         $cartSummaryDetails = $cart->getSummaryDetails(null, true);
         $totalShippingTaxExc = $cartSummaryDetails['total_shipping_tax_exc'];
         $subTotal = $cartSummaryDetails['total_price_without_tax'] - $cartSummaryDetails['total_shipping_tax_exc'];
         $totalTax = $cartSummaryDetails['total_tax'];
 
+        $currency = new Currency($cart->id_currency);
+        $currencyDecimals = is_array($currency) ? (int) $currency['decimals'] : (int) $currency->decimals;
+        $decimals = $currencyDecimals * _PS_PRICE_DISPLAY_PRECISION_; // _PS_PRICE_DISPLAY_PRECISION_ deprec 1.7.7 TODO
+
         $total_price = Tools::ps_round($totalShippingTaxExc + $subTotal + $totalTax, $decimals);
-        $amount = (int) number_format($total_price, 2, '', '');
-        $orderId = str_pad($cart->id . 'm' . time() % 1000, 12, '0', STR_PAD_LEFT); // Redsys/Bizum Style
 
-        $addressInvoice = new Address((int) $cart->id_address_invoice);
-        $addressDelivery = new Address((int) $cart->id_address_delivery);
+        return (int) number_format($total_price, 2, '', '');
+    }
 
-        $stateInvoice = (int) $addressInvoice->id_state > 0 ?
-            new State($addressInvoice->id_state, $langId) : new State();
-        $stateInvoiceName = $stateInvoice->name ?: '';
-
-        $stateDelivery = (int) $addressDelivery->id_state > 0 ?
-            new State($addressDelivery->id_state, $langId) : new State();
-        $stateDeliveryName = $stateDelivery->name ?: '';
-
-        $countryInvoice = new Country($addressInvoice->id_country, $langId);
-        $countryDelivery = new Country($addressInvoice->id_country, $langId);
-
+    public function getCustomerData($returnMoneiCustomerObject = false)
+    {
+        $customer = $this->context->customer;
         $customer->email = str_replace(':', '', $customer->email);
 
-        $moneiCustomer = (new MoneiCustomer())
-            ->setName($customer->firstname . ' ' . $customer->lastname)
-            ->setEmail($customer->email)
-            ->setPhone($addressInvoice->phone);
+        $addressInvoice = new Address((int) $this->context->cart->id_address_invoice);
 
-        $moneiAddressBilling = (new MoneiAddress())
-            ->setLine1($addressInvoice->address1)
-            ->setLine2($addressInvoice->address2)
-            ->setZip($addressInvoice->postcode)
-            ->setCity($addressInvoice->city)
-            ->setState($stateInvoiceName)
-            ->setCountry($countryInvoice->iso_code);
+        $customerData = [
+            'name' => $customer->firstname . ' ' . $customer->lastname,
+            'email' => $customer->email,
+            'phone' => (empty($addressInvoice->phone_mobile) ? $addressInvoice->phone : $addressInvoice->phone_mobile)
+        ];
 
-        $moneiAddressShipping = (new MoneiAddress())
-            ->setLine1($addressDelivery->address1)
-            ->setLine2($addressDelivery->address2)
-            ->setZip($addressDelivery->postcode)
-            ->setCity($addressDelivery->city)
-            ->setState($stateDeliveryName)
-            ->setCountry($countryDelivery->iso_code);
+        if ($returnMoneiCustomerObject) {
+            return (new MoneiCustomer())
+                ->setName($customerData['name'])
+                ->setEmail($customerData['email'])
+                ->setPhone($customerData['phone']);
+        }
 
-        $moneiBillingDetails = (new MoneiBillingDetails())
-            ->setName($moneiCustomer->getName())
-            ->setEmail($moneiCustomer->getEmail())
-            ->setPhone($moneiCustomer->getPhone())
-            ->setAddress($moneiAddressBilling);
+        return $customerData;
+    }
 
-        $moneiShippingDetails = (new MoneiShippingDetails())
-            ->setName($moneiCustomer->getName())
-            ->setEmail($moneiCustomer->getEmail())
-            ->setPhone($moneiCustomer->getPhone())
-            ->setAddress($moneiAddressShipping);
+    public function getAddressData($addressId, $returnMoneiBillingObject = false)
+    {
+        $address = new Address((int) $addressId);
+
+        $state = (int) $address->id_state > 0 ?
+            new State($address->id_state, (int) $this->context->language->id) : new State();
+        $stateName = $state->name ?: '';
+
+        $country = new Country($address->id_country, (int) $this->context->language->id);
+
+        $billingData = [
+            'name' => $address->firstname . ' ' . $address->lastname,
+            'email' => $this->context->customer->email,
+            'phone' => (empty($address->phone_mobile) ? $address->phone : $address->phone_mobile),
+            'company' => $address->company,
+            'address' => [
+                'line1' => $address->address1,
+                'line2' => $address->address2,
+                'zip' => $address->postcode,
+                'city' => $address->city,
+                'state' => $stateName,
+                'country' => $country->iso_code
+            ]
+        ];
+
+        if ($returnMoneiBillingObject) {
+            return (new MoneiBillingDetails())
+                ->setName($billingData['name'])
+                ->setEmail($billingData['email'])
+                ->setPhone($billingData['phone'])
+                ->setCompany($billingData['company'])
+                ->setAddress(
+                    (new MoneiAddress())
+                        ->setLine1($billingData['address']['line1'])
+                        ->setLine2($billingData['address']['line2'])
+                        ->setZip($billingData['address']['zip'])
+                        ->setCity($billingData['address']['city'])
+                        ->setState($billingData['address']['state'])
+                        ->setCountry($billingData['address']['country'])
+                );
+        }
+
+        return $billingData;
+    }
+
+    public function createPayment(bool $tokenizeCard = false, int $moneiCardId = 0): MoneiPayment
+    {
+        $moneiClient = new MoneiClient(
+            Configuration::get('MONEI_API_KEY'),
+            Configuration::get('MONEI_ACCOUNT_ID')
+        );
+
+        // check if the cart amount changed, if so, we need to create a new payment.
+        $moneiPaymentId = $this->context->cookie->monei_payment_id;
+        if (!$tokenizeCard && !$moneiCardId && !empty($moneiPaymentId)) {
+            $moneiPayment = $moneiClient->payments->getPayment($moneiPaymentId);
+
+            if (!empty($moneiPayment->getPaymentMethod()) || (int) $moneiPayment->getAmount() !== $this->getCartAmount()) {
+                $moneiPaymentId = null;
+                unset($this->context->cookie->monei_payment_id);
+            } else {
+                return $moneiPayment;
+            }
+        }
+
+        $cart = $this->context->cart;
+        $link = $this->context->link;
+        $currency = new Currency($cart->id_currency);
+
+        $orderId = str_pad($cart->id . 'm' . time() % 1000, 12, '0', STR_PAD_LEFT); // Redsys/Bizum Style
 
         $moneiPayment = new MoneiPayment();
         $moneiPayment
-            ->setAmount($amount)
-            ->setCurrency($currency->iso_code)
             ->setOrderId($orderId)
+            ->setAmount($this->getCartAmount())
+            ->setCurrency($currency->iso_code)
+            ->setCustomer($this->getCustomerData(true))
+            ->setBillingDetails($this->getAddressData((int) $cart->id_address_invoice, true))
+            ->setShippingDetails($this->getAddressData((int) $cart->id_address_delivery, true))
             ->setCompleteUrl(
                 $link->getModuleLink($this->name, 'confirmation', [
                     'success' => 1,
@@ -1025,13 +1069,11 @@ class Monei extends PaymentModule
             )
             ->setCancelUrl(
                 $link->getPageLink('order', null, null, 'step=3')
-            )
-            ->setBillingDetails($moneiBillingDetails)
-            ->setShippingDetails($moneiShippingDetails);
+            );
 
-        // Check for available payment methods
         $payment_methods = [];
 
+        // Check for available payment methods
         if (!Configuration::get('MONEI_ALLOW_ALL')) {
             if (Tools::isSubmit('method')) {
                 $param_method = Tools::getValue('method', 'card');
@@ -1072,35 +1114,42 @@ class Monei extends PaymentModule
         }
 
         $moneiPayment->setAllowedPaymentMethods($payment_methods);
+        if ($tokenizeCard) {
+            $moneiPayment->setGeneratePaymentToken(true);
+        } else if ($moneiCardId) {
+            $belongsToCustomer = MoneiCard::belongsToCustomer(
+                $moneiCardId,
+                $this->context->customer->id
+            );
 
-        // Save the information before sending it to the API
-        PsOrderHelper::saveTransaction($moneiPayment, true);
+            if ($belongsToCustomer) {
+                $tokenizedCard = new MoneiCard($moneiCardId);
 
-        return $moneiPayment;
-    }
-
-    public function createPaymentInMonei($moneiPayment)
-    {
-        $moneiClient = new MoneiClient(
-            Configuration::get('MONEI_API_KEY'),
-            Configuration::get('MONEI_ACCOUNT_ID')
-        );
+                $moneiPayment->setPaymentToken($tokenizedCard->tokenized);
+                $moneiPayment->setGeneratePaymentToken(false);
+            }
+        }
 
         try {
+            // Save the information before sending it to the API
+            PsOrderHelper::saveTransaction($moneiPayment, true);
+
             $moneiPaymentResponse = $moneiClient->payments->createPayment($moneiPayment);
+
+            // Only save the payment id if dont tokenize the card or the card id is not set
+            if (!$tokenizeCard && !$moneiCardId) {
+                $this->context->cookie->monei_payment_id = $moneiPaymentResponse->getId();
+            }
+
+            return $moneiPaymentResponse;
         } catch (Exception $ex) {
             PrestaShopLogger::addLog(
-                'MONEI - Exception - monei.php - getPaymentMethods: ' . $ex->getMessage() . ' - ' . $ex->getFile(),
+                'MONEI - Exception - monei.php - createPayment: ' . $ex->getMessage() . ' - ' . $ex->getFile(),
                 PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR
             );
 
             return false;
         }
-
-        // Save the information after sending it to the API
-        PsOrderHelper::saveTransaction($moneiPaymentResponse);
-
-        return $moneiPaymentResponse;
     }
 
     public function createOrUpdateOrder($moneiPaymentId, $redirectToConfirmationPage = false)
@@ -1271,6 +1320,9 @@ class Monei extends PaymentModule
             }
         }
 
+        // remove monei payment id from cookie
+        unset($this->context->cookie->monei_payment_id);
+
         // Save log (required from API for tokenization)
         if (!PsOrderHelper::saveTransaction($moneiPayment, false, $is_refund, true, $failed)) {
             throw new ApiException('Unable to save transaction information');
@@ -1364,40 +1416,18 @@ class Monei extends PaymentModule
      */
     private function getPaymentMethods()
     {
-        $countryIsoCode = $this->context->country->iso_code;
-        $currencyIsoCode = $this->context->currency->iso_code;
-        $addressInvoice = new Address($this->context->cart->id_address_invoice);
-        if (Validate::isLoadedObject($addressInvoice)) {
-            $countryInvoice = new Country($addressInvoice->id_country);
-            $countryIsoCode = $countryInvoice->iso_code;
+        $cart = $this->context->cart;
+
+        $moneiPayment = $this->createPayment();
+        if (!$moneiPayment) {
+            return;
         }
 
-        $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
-        $transactionId = $crypto->hash(
-            $this->context->cart->id . $this->context->cart->id_customer, _COOKIE_KEY_
-        );
-
-        $moneiPayment = $this->createPaymentObject();
+        $moneiPaymentId = $moneiPayment->getId();
         $moneiClient = new MoneiClient(
             Configuration::get('MONEI_API_KEY'),
             Configuration::get('MONEI_ACCOUNT_ID')
         );
-
-        try {
-            $moneiPaymentResponse = $moneiClient->payments->createPayment($moneiPayment);
-        } catch (Exception $ex) {
-            PrestaShopLogger::addLog(
-                'MONEI - Exception - monei.php - getPaymentMethods: ' . $ex->getMessage() . ' - ' . $ex->getFile(),
-                PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR
-            );
-
-            return false;
-        }
-
-        // Save the information after sending it to the API
-        PsOrderHelper::saveTransaction($moneiPaymentResponse);
-
-        $moneiPaymentId = $moneiPaymentResponse->getId();
 
         $moneiAccount = $moneiClient->getMoneiAccount();
         $moneiPaymentMethod = $moneiAccount->getPaymentInformation($moneiPaymentId)->getPaymentMethodsAllowed();
@@ -1413,6 +1443,19 @@ class Monei extends PaymentModule
         $paymentMethods = [];
         $paymentOptionList = [];
 
+        $countryIsoCode = $this->context->country->iso_code;
+        $currencyIsoCode = $this->context->currency->iso_code;
+        $addressInvoice = new Address($cart->id_address_invoice);
+        if (Validate::isLoadedObject($addressInvoice)) {
+            $countryInvoice = new Country($addressInvoice->id_country);
+            $countryIsoCode = $countryInvoice->iso_code;
+        }
+
+        $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
+        $transactionId = $crypto->hash(
+            $cart->id . $cart->id_customer, _COOKIE_KEY_
+        );
+
         // Credit Card
         if (Configuration::get('MONEI_ALLOW_CARD') && $moneiPaymentMethod->isPaymentMethodAllowed(MoneiPaymentMethods::CARD, $currencyIsoCode)) {
             $paymentOptionList['card'] = [
@@ -1426,7 +1469,6 @@ class Monei extends PaymentModule
                 $redirectUrl = $this->context->link->getModuleLink($this->name, 'redirect', [
                     'method' => 'card',
                     'transaction_id' => $transactionId,
-                    'tokenize_card' => 0
                 ]);
 
                 if (Configuration::get('MONEI_TOKENIZE')) {
@@ -1458,7 +1500,6 @@ class Monei extends PaymentModule
                         'method' => 'card',
                         'transaction_id' => $transactionId,
                         'id_monei_card' => $credit_card->id,
-                        'tokenize_card' => 0,
                     ]);
 
                     $paymentOptionList['card-' . (int) $card['id_monei_tokens']] = [
@@ -1493,8 +1534,9 @@ class Monei extends PaymentModule
             $paymentOptionList['applePay'] = [
                 'method' => 'applePay',
                 'callToActionText' => $this->l('Apple Pay'),
-                'additionalInformation' => $template,
+                'additionalInformation' => '',
                 'logo' => Media::getMediaPath(_PS_MODULE_DIR_ . $this->name . '/views/img/payments/apple-pay.svg'),
+                'binary' => true,
             ];
         }
 
@@ -1505,8 +1547,9 @@ class Monei extends PaymentModule
             $paymentOptionList['googlePay'] = [
                 'method' => 'googlePay',
                 'callToActionText' => $this->l('Google Pay'),
-                'additionalInformation' => $template,
+                'additionalInformation' => '',
                 'logo' => Media::getMediaPath(_PS_MODULE_DIR_ . $this->name . '/views/img/payments/google-pay.svg'),
+                'binary' => true,
             ];
         }
 
@@ -1644,20 +1687,25 @@ class Monei extends PaymentModule
         $paymentMethodsToDisplay = [];
 
         $paymentMethods = $this->getPaymentMethods();
-        foreach ($paymentMethods['paymentOptions'] as $paymentOption) {
-            if ($paymentOption->isBinary()) {
-                $paymentMethodsToDisplay[] = $paymentOption->getModuleName();
-            }
-        }
-
         if ($paymentMethods) {
-            $this->context->smarty->assign([
-                'paymentMethodsToDisplay' => $paymentMethodsToDisplay,
-                'moneiPaymentId' => $paymentMethods['moneiPaymentId'],
-                'moneiAmount' => Tools::displayPrice($this->context->cart->getOrderTotal()),
-            ]);
+            foreach ($paymentMethods['paymentOptions'] as $paymentOption) {
+                if ($paymentOption->isBinary()) {
+                    $paymentMethodsToDisplay[] = $paymentOption->getModuleName();
+                }
+            }
 
-            return $this->fetch('module:monei/views/templates/hook/displayPaymentByBinaries.tpl');
+            if ($paymentMethodsToDisplay) {
+                $this->context->smarty->assign([
+                    'paymentMethodsToDisplay' => $paymentMethodsToDisplay,
+                    'moneiPaymentId' => $paymentMethods['moneiPaymentId'],
+                    'moneiAmount' => Tools::displayPrice($this->context->cart->getOrderTotal()),
+                    'customerData' => $this->getCustomerData(),
+                    'billingData' => $this->getAddressData((int) $this->context->cart->id_address_invoice),
+                    'shippingData' => $this->getAddressData((int) $this->context->cart->id_address_delivery),
+                ]);
+
+                return $this->fetch('module:monei/views/templates/hook/displayPaymentByBinaries.tpl');
+            }
         }
     }
 

--- a/src/Monei/CoreHelpers/PsTools.php
+++ b/src/Monei/CoreHelpers/PsTools.php
@@ -16,17 +16,5 @@ class PsTools
             return true;
         }
         return false;
-
-        // $user_agent = $_SERVER['HTTP_USER_AGENT'];
-        // $browser = new \foroco\BrowserDetection();
-        // $browser_info = $browser->getBrowser($user_agent);
-        // $os_info = $browser->getOS($user_agent);
-
-        // if ((array_key_exists('os_family', $os_info) && $os_info['os_family'] == 'macintosh') &&
-        //     (array_key_exists('browser_name', $browser_info) &&
-        //         strpos($browser_info['browser_name'], 'Safari') !== false)) {
-        //     return true;
-        // }
-        // return false;
     }
 }

--- a/views/js/front.js
+++ b/views/js/front.js
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (typeof initMoneiBizum !== typeof undefined) {
                 initMoneiBizum();
             }
+            if (typeof initMoneiPaymentRequest !== typeof undefined) {
+                initMoneiPaymentRequest();
+            }
         });
     // support module: onepagecheckoutps - v4 - PresTeamShop
     } else if (typeof AppOPC !== typeof undefined) {
@@ -18,6 +21,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (typeof initMoneiBizum !== typeof undefined) {
                 initMoneiBizum();
             }
+            if (typeof initMoneiPaymentRequest !== typeof undefined) {
+                initMoneiPaymentRequest();
+            }
         });
     } else {
         if (typeof initMoneiCard !== typeof undefined) {
@@ -25,6 +31,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (typeof initMoneiBizum !== typeof undefined) {
             initMoneiBizum();
+        }
+        if (typeof initMoneiPaymentRequest !== typeof undefined) {
+            initMoneiPaymentRequest();
         }
     }
 });

--- a/views/js/front.js
+++ b/views/js/front.js
@@ -8,8 +8,11 @@ document.addEventListener('DOMContentLoaded', () => {
             if (typeof initMoneiBizum !== typeof undefined) {
                 initMoneiBizum();
             }
-            if (typeof initMoneiPaymentRequest !== typeof undefined) {
-                initMoneiPaymentRequest();
+            if (typeof initMoneiGooglePay !== typeof undefined) {
+                initMoneiGooglePay();
+            }
+            if (typeof initMoneiApplePay !== typeof undefined) {
+                initMoneiApplePay();
             }
         });
     // support module: onepagecheckoutps - v4 - PresTeamShop
@@ -21,8 +24,11 @@ document.addEventListener('DOMContentLoaded', () => {
             if (typeof initMoneiBizum !== typeof undefined) {
                 initMoneiBizum();
             }
-            if (typeof initMoneiPaymentRequest !== typeof undefined) {
-                initMoneiPaymentRequest();
+            if (typeof initMoneiGooglePay !== typeof undefined) {
+                initMoneiGooglePay();
+            }
+            if (typeof initMoneiApplePay !== typeof undefined) {
+                initMoneiApplePay();
             }
         });
     } else {
@@ -32,8 +38,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (typeof initMoneiBizum !== typeof undefined) {
             initMoneiBizum();
         }
-        if (typeof initMoneiPaymentRequest !== typeof undefined) {
-            initMoneiPaymentRequest();
+        if (typeof initMoneiGooglePay !== typeof undefined) {
+            initMoneiGooglePay();
+        }
+        if (typeof initMoneiApplePay !== typeof undefined) {
+            initMoneiApplePay();
         }
     }
 });

--- a/views/templates/front/onsite_card.tpl
+++ b/views/templates/front/onsite_card.tpl
@@ -4,8 +4,8 @@
 <div class="form-group">
     <div id="monei-card_container" class="form-control"></div>
 </div>
+<div id="monei-card-errors" class="form-group"></div>
 <div class="form-group">
     <input class="input-form" type="checkbox" name="monei-tokenize-card" id="monei-tokenize-card">
     <label class="form-control-label monei-tokenize-card" for="monei-tokenize-card">{l s='Save Card details for future payments' mod='monei'}</label>
 </div>
-<div id="monei-card-errors" class="form-group"></div>

--- a/views/templates/hook/displayPaymentByBinaries.tpl
+++ b/views/templates/hook/displayPaymentByBinaries.tpl
@@ -203,6 +203,11 @@
 
           var moneiCardInput = monei.CardInput({
             paymentId: window.moneiPaymentId,
+            onChange: function (event) {
+              moneiCardErrors.innerHTML = '';
+              moneiCardButton.classList.remove('disabled');
+              moneiCardButton.disabled = false;
+            },
             onEnter: () => {
               moneiPaymentFormButton.click();
             },

--- a/views/templates/hook/displayPaymentByBinaries.tpl
+++ b/views/templates/hook/displayPaymentByBinaries.tpl
@@ -1,5 +1,8 @@
 <script>
   window.moneiPaymentId = '{$moneiPaymentId|escape:'htmlall':'UTF-8'}';
+  window.moneiCustomerData = {$customerData|json_encode nofilter};
+  window.moneiBillingData = {$billingData|json_encode nofilter};
+  window.moneiShippingData = {$shippingData|json_encode nofilter};
 
   {literal}
     var moneiTokenHandler = async (paymentToken, cardholderName, paymentButton) => {
@@ -11,7 +14,8 @@
       if (cardholderName) {
         params.paymentMethod = {
           card: {
-            cardholderName
+            cardholderName,
+            'cardholderEmail': window.moneiCustomerData.email,
           }
         };
       }
@@ -20,6 +24,10 @@
       if (saveCard && saveCard.checked) {
         params.generatePaymentToken = true;
       }
+
+      params.customer = window.moneiCustomerData;
+      params.billingDetails = window.moneiBillingData;
+      params.shippingDetails = window.moneiShippingData;
 
       Swal.fire({
         allowOutsideClick: false,
@@ -34,23 +42,12 @@
 
             console.log('moneiTokenHandler - confirmPayment', params, result);
 
-            Swal.hideLoading();
-
             if (result.nextAction && result.nextAction.mustRedirect) {
               window.location.assign(result.nextAction.redirectUrl);
             } else {
               const icon = result.status === 'SUCCEEDED' ? 'success' : 'error';
 
               if (result.status === 'SUCCEEDED') {
-                Swal.fire({
-                  title: result.status,
-                  text: result.statusMessage,
-                  icon,
-                  allowOutsideClick: false,
-                  allowEscapeKey: false,
-                  showConfirmButton: false,
-                });
-
                 window.location.assign(result.nextAction.redirectUrl);
               } else {
                 Swal.fire({
@@ -83,6 +80,20 @@
           }
         },
       });
+    };
+
+    var moneiValidConditions = () => {
+      const conditionsToApprove = document.getElementById('conditions-to-approve');
+      if (conditionsToApprove) {
+        const requiredCheckboxes = conditionsToApprove.querySelectorAll('input[type="checkbox"][required]');
+        for (let i = 0; i < requiredCheckboxes.length; i++) {
+          if (!requiredCheckboxes[i].checked) {
+            return false;
+          }
+        }
+
+        return true;
+      }
     };
   {/literal}
 </script>
@@ -123,16 +134,7 @@
             height: 42
           },
           onBeforeOpen: () => {
-            const conditionsToApprove = document.getElementById('conditions-to-approve');
-            if (conditionsToApprove) {
-              const requiredCheckboxes = conditionsToApprove.querySelectorAll('input[type="checkbox"][required]');
-              for (let i = 0; i < requiredCheckboxes.length; i++) {
-                if (!requiredCheckboxes[i].checked) {
-                  return false;
-                }
-              }
-              return true;
-            }
+            return moneiValidConditions();
           },
           onSubmit(result) {
             if (result.token) {
@@ -250,5 +252,44 @@
         }
       </script>
     {/literal}
+  {elseif $paymentOptionName eq 'monei-googlePay' or $paymentOptionName eq 'monei-applePay'}
+    <script>
+      function initMoneiPaymentRequest() {
+        var moneiPaymentRequestButtonsContainer = document.getElementById('{$paymentOptionName}-buttons-container');
+        if (moneiPaymentRequestButtonsContainer === null) {
+          return;
+        }
+
+        var moneiPaymentRequestRenderContainer = moneiPaymentRequestButtonsContainer.querySelector('.{$paymentOptionName}_render');
+        if (moneiPaymentRequestRenderContainer === null) {
+          return;
+        }
+
+        monei.PaymentRequest({
+          paymentId: window.moneiPaymentId,
+          style: {
+            height: 42
+          },
+          onBeforeOpen: moneiValidConditions,
+          onSubmit(result) {
+            if (result.token) {
+              moneiTokenHandler(result.token);
+            }
+
+            console.log('onSubmit - Payment Request', result);
+          },
+          onError(error) {
+            Swal.fire({
+              title: error.status + '(' + error.statusCode + ')',
+              text: error.message,
+              icon: 'error',
+            });
+
+            console.log('onError - Payment Request', error);
+          }
+        })
+        .render(moneiPaymentRequestRenderContainer);
+      }
+    </script>
   {/if}
 {/foreach}

--- a/views/templates/hook/displayPaymentByBinaries.tpl
+++ b/views/templates/hook/displayPaymentByBinaries.tpl
@@ -252,15 +252,15 @@
         }
       </script>
     {/literal}
-  {elseif $paymentOptionName eq 'monei-googlePay' or $paymentOptionName eq 'monei-applePay'}
+  {elseif $paymentOptionName eq 'monei-googlePay'}
     <script>
-      function initMoneiPaymentRequest() {
-        var moneiPaymentRequestButtonsContainer = document.getElementById('{$paymentOptionName}-buttons-container');
+      function initMoneiGooglePay() {
+        var moneiPaymentRequestButtonsContainer = document.getElementById('monei-googlePay-buttons-container');
         if (moneiPaymentRequestButtonsContainer === null) {
           return;
         }
 
-        var moneiPaymentRequestRenderContainer = moneiPaymentRequestButtonsContainer.querySelector('.{$paymentOptionName}_render');
+        var moneiPaymentRequestRenderContainer = moneiPaymentRequestButtonsContainer.querySelector('.monei-googlePay_render');
         if (moneiPaymentRequestRenderContainer === null) {
           return;
         }
@@ -276,7 +276,7 @@
               moneiTokenHandler(result.token);
             }
 
-            console.log('onSubmit - Payment Request', result);
+            console.log('onSubmit - Google Pay', result);
           },
           onError(error) {
             Swal.fire({
@@ -285,7 +285,46 @@
               icon: 'error',
             });
 
-            console.log('onError - Payment Request', error);
+            console.log('onError - Google Pay', error);
+          }
+        })
+        .render(moneiPaymentRequestRenderContainer);
+      }
+    </script>
+  {elseif $paymentOptionName eq 'monei-applePay'}
+    <script>
+      function initMoneiApplePay() {
+        var moneiPaymentRequestButtonsContainer = document.getElementById('monei-applePay-buttons-container');
+        if (moneiPaymentRequestButtonsContainer === null) {
+          return;
+        }
+
+        var moneiPaymentRequestRenderContainer = moneiPaymentRequestButtonsContainer.querySelector('.monei-applePay_render');
+        if (moneiPaymentRequestRenderContainer === null) {
+          return;
+        }
+
+        monei.PaymentRequest({
+          paymentId: window.moneiPaymentId,
+          style: {
+            height: 42
+          },
+          onBeforeOpen: moneiValidConditions,
+          onSubmit(result) {
+            if (result.token) {
+              moneiTokenHandler(result.token);
+            }
+
+            console.log('onSubmit - Apple Pay', result);
+          },
+          onError(error) {
+            Swal.fire({
+              title: error.status + '(' + error.statusCode + ')',
+              text: error.message,
+              icon: 'error',
+            });
+
+            console.log('onError - Apple Pay', error);
           }
         })
         .render(moneiPaymentRequestRenderContainer);


### PR DESCRIPTION
- We restructured the creation of the Payment to generate fewer payment intents and reuse the one previously created (using cookies).
- Task #41 has been completed to prevent the "payment success" popup from being displayed. The error popup is left as is, to avoid using cookies or the URL to display these messages.
- Google Pay and Apple Pay buttons have been implemented as payment options. #36 