### PR TITLE
Revision: 41 - payments without orders

### DIFF
--- a/controllers/front/confirmation.php
+++ b/controllers/front/confirmation.php
@@ -13,10 +13,23 @@ class MoneiConfirmationModuleFrontController extends ModuleFrontController
 
         $moneiPaymentId = Tools::getValue('id');
         $moneiStatus = Tools::getValue('status');
-        if (!empty($moneiPaymentId) && $moneiStatus !== MoneiPaymentStatus::CANCELED) {
-            $this->module->createOrUpdateOrder($moneiPaymentId, true);
-        } else {
-            Tools::redirect('index.php?controller=order');
+
+        try {
+            if (!empty($moneiPaymentId) && $moneiStatus !== MoneiPaymentStatus::CANCELED) {
+                $this->module->createOrUpdateOrder($moneiPaymentId, true);
+            } else {
+                Tools::redirect('index.php?controller=order');
+            }
+        } catch (Exception $ex) {
+            PrestaShopLogger::addLog(
+                'MONEI - Exception - validation.php - postProcess: ' . $ex->getMessage() . ' - ' . $ex->getFile(),
+                PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR
+            );
+
+            $this->context->cookie->monei_error = $ex->getMessage();
+            Tools::redirect(
+                $this->context->link->getModuleLink($this->module->name, 'errors')
+            );
         }
     }
 }

--- a/controllers/front/redirect.php
+++ b/controllers/front/redirect.php
@@ -44,12 +44,6 @@ class MoneiRedirectModuleFrontController extends ModuleFrontController
             $moneiOrderId = $moneiPayment->getOrderId();
             $moneiId = Monei::getIdByInternalOrder($moneiOrderId);
 
-            // Save the Payment ID
-            $monei = new Monei($moneiId);
-            $monei->id_cart = (int) $cart->id;
-            $monei->id_order_monei = pSQL($moneiPayment->getId());
-            $monei->save();
-
             // Convert the cart to order
             $orderState = new OrderState(Configuration::get('MONEI_STATUS_PENDING'));
             if (Configuration::get('MONEI_CART_TO_ORDER') && Validate::isLoadedObject($orderState)) {
@@ -83,6 +77,7 @@ class MoneiRedirectModuleFrontController extends ModuleFrontController
                 // Check id_order and save it
                 $orderId = (int) Order::getIdByCartId($cart->id);
                 if ($orderId) {
+                    $monei = new Monei($moneiId);
                     $monei->id_order = $orderId;
                     $monei->save();
                 }
@@ -98,14 +93,10 @@ class MoneiRedirectModuleFrontController extends ModuleFrontController
             }
         } catch (ApiException $ex) {
             $this->context->cookie->monei_error = 'API: ' . $ex->getMessage();
-            Tools::redirect($this->context->link->getModuleLink($this->module->name, 'errors', [
-                'cart_id' => (int)$cart->id
-            ]));
+            Tools::redirect($this->context->link->getModuleLink($this->module->name, 'errors'));
         } catch (Exception $ex) {
             $this->context->cookie->monei_error = 'API: ' . $ex->getMessage();
-            Tools::redirect($this->context->link->getModuleLink($this->module->name, 'errors', [
-                'cart_id' => (int)$cart->id
-            ]));
+            Tools::redirect($this->context->link->getModuleLink($this->module->name, 'errors'));
         }
 
         exit;

--- a/src/Monei/CoreHelpers/PsOrderHelper.php
+++ b/src/Monei/CoreHelpers/PsOrderHelper.php
@@ -60,6 +60,7 @@ class PsOrderHelper
             $id_order = \Order::getIdByCartId($id_cart);
             $monei->id_order = (int)$id_order > 0 ? (int)$id_order : null;
             $monei->id_order_internal = pSQL($payment->getOrderId());
+            $monei->id_order_monei = pSQL($payment->getId());
             if ($save_amount) {
                 $monei->amount = (int)$payment->getAmount();
             }

--- a/views/templates/front/cards.tpl
+++ b/views/templates/front/cards.tpl
@@ -31,7 +31,7 @@
                         <td>{$monei_card.id_monei_tokens|escape:'html':'UTF-8'}</td>
                         <td>
                             <img width="48"
-                                 src="{$modules_dir|escape:'html':'UTF-8'}/monei/views/img/{$monei_card.brand|escape:'html':'UTF-8'}.png"
+                                 src="{$modules_dir|escape:'html':'UTF-8'}/monei/views/img/payments/{$monei_card.brand|escape:'html':'UTF-8'}.svg"
                                  class="img img-responsive" alt="{$monei_card.brand|escape:'html':'UTF-8'}">
                         </td>
                         <td class="text-center">


### PR DESCRIPTION
- In very specific cases, with redirection enabled for payments, there was an issue where orders were not generated in PrestaShop after a successful transaction.
- Logs have been improved for future debugging.
- If a transaction fails, a clear message is now displayed explaining what happened.