### PR TITLE
Revision: 59 - delay 1 second to process order

### DIFF
--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -26,6 +26,8 @@ class MoneiValidationModuleFrontController extends ModuleFrontController
         $requestBody = Tools::file_get_contents('php://input');
         $sigHeader = $_SERVER['HTTP_MONEI_SIGNATURE'];
 
+        sleep(1); // Adding a delay to prevent processing too quickly and potentially generating duplicate orders.
+
         try {
             $this->module->getMoneiClient()->verifySignature($requestBody, $sigHeader);
         } catch (ApiException $e) {


### PR DESCRIPTION
- Adding a delay to prevent processing too quickly and potentially generating duplicate orders.