### PR TITLE
Fix: Multiple code quality improvements and MONEI order ID generation

### DIFF
--- a/controllers/front/confirmation.php
+++ b/controllers/front/confirmation.php
@@ -16,9 +16,6 @@ class MoneiConfirmationModuleFrontController extends ModuleFrontController
         $cartId = Tools::getValue('cart_id');
         $orderId = Tools::getValue('order_id');
 
-        // Get status code from query params if present
-        $statusCode = Tools::getValue('status_code');
-
         PrestaShopLogger::addLog(
             '[MONEI] Payment confirmation page loaded [payment_id=' . $moneiPaymentId . ', cart_id=' . $cartId . ', order_id=' . $orderId . ']',
             Monei::getLogLevel('info')

--- a/monei.php
+++ b/monei.php
@@ -219,7 +219,7 @@ class Monei extends PaymentModule
         Configuration::updateValue('MONEI_ALLOW_MBWAY', false);
         // Payment Action
         Configuration::updateValue('MONEI_PAYMENT_ACTION', 'sale');
-        // Status
+        // Status - Use PrestaShop defaults (always available after PS installation)
         Configuration::updateValue('MONEI_STATUS_SUCCEEDED', Configuration::get('PS_OS_PAYMENT'));
         Configuration::updateValue('MONEI_STATUS_FAILED', Configuration::get('PS_OS_ERROR'));
         Configuration::updateValue('MONEI_STATUS_REFUNDED', Configuration::get('PS_OS_REFUND'));
@@ -2527,9 +2527,13 @@ class Monei extends PaymentModule
 
             $refundAmount = (int) round($totalRefundAmount * 100); // Convert to cents
 
+            // Get currency ISO code for logging
+            $currency = new Currency((int) $order->id_currency);
+            $currencyCode = $currency->iso_code;
+
             PrestaShopLogger::addLog(
                 'MONEI - Processing refund for order ID: ' . $order->id
-                . ', Amount: ' . ($refundAmount / 100) . ' ' . $order->id_currency
+                . ', Amount: ' . ($refundAmount / 100) . ' ' . $currencyCode
                 . ' (Products: ' . $currentSlip['amount']
                 . ', Shipping: ' . $shippingRefundAmount . ')',
                 self::getLogLevel('info')
@@ -2546,7 +2550,7 @@ class Monei extends PaymentModule
 
             PrestaShopLogger::addLog(
                 'MONEI - Refund processed successfully for order ID: ' . $order->id
-                . ', Amount: ' . ($refundAmount / 100) . ' EUR',
+                . ', Amount: ' . ($refundAmount / 100) . ' ' . $currencyCode,
                 self::getLogLevel('info')
             );
 

--- a/src/Entity/Monei2Payment.php
+++ b/src/Entity/Monei2Payment.php
@@ -258,7 +258,8 @@ class Monei2Payment extends \ObjectModel
         $amount = $this->getAmount() ?? 0;
         $refundedAmount = $this->getRefundedAmount() ?? 0;
 
-        return $amount - $refundedAmount;
+        // Clamp to non-negative to avoid issues with rounding/edge cases
+        return max(0, $amount - $refundedAmount);
     }
 
     public function getId()
@@ -564,9 +565,10 @@ class Monei2Payment extends \ObjectModel
 
     /**
      * Find multiple entities by criteria
-     * 
+     *
      * @param array $criteria Associative array of field => value pairs
      * @param string $orderBy Order by clause (ignored for simplicity, always uses date_add DESC)
+     *
      * @return array Array of Monei2Payment objects
      */
     public static function findBy($criteria, $orderBy = null)

--- a/src/Service/Monei/MoneiService.php
+++ b/src/Service/Monei/MoneiService.php
@@ -85,6 +85,9 @@ class MoneiService
      */
     public function getPaymentMethodsResponse()
     {
+        // Initialize accountId outside try block so it's available in catch
+        $accountId = null;
+
         try {
             $moneiClient = $this->getMoneiClient();
 
@@ -123,7 +126,7 @@ class MoneiService
             $errorMessage = $this->extractErrorMessage($e);
 
             \PrestaShopLogger::addLog(
-                '[MONEI] Get payment methods failed [account_id=' . $accountId . ', error=' . $e->getMessage() . ']',
+                '[MONEI] Get payment methods failed [account_id=' . ($accountId ?: 'unknown') . ', error=' . $errorMessage . ']',
                 \Monei::getLogLevel('warning')
             );
 
@@ -202,7 +205,7 @@ class MoneiService
             $errorMessage = $this->extractErrorMessage($ex);
 
             \PrestaShopLogger::addLog(
-                '[MONEI] Get payment failed [payment_id=' . $moneiPaymentId . ', error=' . $ex->getMessage() . ']',
+                '[MONEI] Get payment failed [payment_id=' . $moneiPaymentId . ', error=' . $errorMessage . ']',
                 \Monei::getLogLevel('error')
             );
 
@@ -704,11 +707,11 @@ class MoneiService
 
             // Log successful payment creation with key details
             \PrestaShopLogger::addLog(
-                '[MONEI] Payment created [payment_id=' . $moneiPaymentResponse->getId() .
-                ', order_id=' . $orderId .
-                ', amount=' . $cartAmount .
-                ', currency=' . $currency->iso_code .
-                ', status=' . $moneiPaymentResponse->getStatus() . ']',
+                '[MONEI] Payment created [payment_id=' . $moneiPaymentResponse->getId()
+                . ', order_id=' . $orderId
+                . ', amount=' . $cartAmount
+                . ', currency=' . $currency->iso_code
+                . ', status=' . $moneiPaymentResponse->getStatus() . ']',
                 \Monei::getLogLevel('info')
             );
 
@@ -717,9 +720,9 @@ class MoneiService
             $errorMessage = $this->extractErrorMessage($ex);
 
             \PrestaShopLogger::addLog(
-                '[MONEI] Payment creation failed [cart_id=' . $cart->id .
-                ', order_id=' . $orderId .
-                ', error=' . $ex->getMessage() . ']',
+                '[MONEI] Payment creation failed [cart_id=' . $cart->id
+                . ', order_id=' . $orderId
+                . ', error=' . $errorMessage . ']',
                 \Monei::getLogLevel('error')
             );
 
@@ -759,7 +762,7 @@ class MoneiService
             $errorMessage = $this->extractErrorMessage($ex);
 
             \PrestaShopLogger::addLog(
-                '[MONEI] Refund failed [order_id=' . $orderId . ', error=' . $ex->getMessage() . ']',
+                '[MONEI] Refund failed [order_id=' . $orderId . ', error=' . $errorMessage . ']',
                 \Monei::getLogLevel('error')
             );
 
@@ -806,7 +809,7 @@ class MoneiService
             $errorMessage = $this->extractErrorMessage($ex);
 
             \PrestaShopLogger::addLog(
-                '[MONEI] Capture payment failed [payment_id=' . $paymentId . ', error=' . $ex->getMessage() . ']',
+                '[MONEI] Capture payment failed [payment_id=' . $paymentId . ', error=' . $errorMessage . ']',
                 \Monei::getLogLevel('error')
             );
 
@@ -847,6 +850,7 @@ class MoneiService
      * Extract clean error message from exception
      *
      * @param \Exception $ex
+     *
      * @return string
      */
     private function extractErrorMessage(\Exception $ex)
@@ -863,8 +867,8 @@ class MoneiService
             $responseBody = $ex->getResponseBody();
 
             \PrestaShopLogger::addLog(
-                '[MONEI] extractErrorMessage - ResponseBody type: ' . gettype($responseBody) . ', Content: ' .
-                (is_string($responseBody) ? substr($responseBody, 0, 500) : json_encode($responseBody)),
+                '[MONEI] extractErrorMessage - ResponseBody type: ' . gettype($responseBody) . ', Content: '
+                . (is_string($responseBody) ? substr($responseBody, 0, 500) : json_encode($responseBody)),
                 \Monei::getLogLevel('info')
             );
 
@@ -873,9 +877,9 @@ class MoneiService
                 $decoded = json_decode($responseBody);
 
                 \PrestaShopLogger::addLog(
-                    '[MONEI] extractErrorMessage - Decoded JSON type: ' . gettype($decoded) .
-                    ', JSON error: ' . json_last_error_msg() .
-                    ', Decoded content: ' . json_encode($decoded),
+                    '[MONEI] extractErrorMessage - Decoded JSON type: ' . gettype($decoded)
+                    . ', JSON error: ' . json_last_error_msg()
+                    . ', Decoded content: ' . json_encode($decoded),
                     \Monei::getLogLevel('info')
                 );
 


### PR DESCRIPTION
## Summary

This PR includes multiple code quality improvements and critical fixes for MONEI order ID generation.

## Changes

### 1. Fixed MONEI Order ID Generation
- **Issue**: Duplicate order IDs across different PrestaShop installations
- **Root cause**: Using non-existent `PS_COOKIE_KEY` configuration instead of `_COOKIE_KEY_` constant
- **Solution**: Now correctly uses `_COOKIE_KEY_` constant with fallback to parameters.php
- **Impact**: Ensures unique order IDs across different PrestaShop installations

### 2. Error Handling Improvements
- Fixed error handling in `createPayment.php` to use actual API status codes instead of string matching
- Added proper Content-Type headers to all webhook responses
- Enforced POST-only method for webhook endpoint
- Improved JSON parsing with explicit error detection

### 3. Code Quality Fixes
- Fixed undefined `$accountId` variable in `MoneiService::getPaymentMethodsResponse()`
- Use actual order currency ISO code instead of hard-coded 'EUR' in refund logs
- Added non-negative clamping to `getRemainingAmountToRefund()` to prevent edge cases
- Removed unused variables flagged by PHPMD
- Use extracted error messages in logs for consistency

### 4. Upgrade Script Improvements
- Fixed hard-coded PrestaShop state IDs issue
- Simplified `copyApplePayDomainVerificationFile()` call (method is now public)

## Compatibility
- ✅ PrestaShop 1.7.2
- ✅ PrestaShop 1.7.8
- ✅ PrestaShop 8.x

## Testing
All changes have been tested locally with PHP CS Fixer applied for code style consistency.