### PR TITLE
Fix: Add missing is_captured column to payment table

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monei-prestashop",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "main": "index.js",
   "repository": "git@github.com:MONEI/MONEI-PrestaShop.git",
   "author": "MONEI <support@monei.com>",

--- a/monei.php
+++ b/monei.php
@@ -17,7 +17,7 @@ class Monei extends PaymentModule
     protected $moneiClient = false;
 
     const NAME = 'monei';
-    const VERSION = '2.0.11';
+    const VERSION = '2.0.12';
 
     private static $serviceContainer;
     private static $serviceList;
@@ -27,7 +27,7 @@ class Monei extends PaymentModule
         $this->displayName = 'MONEI Payments';
         $this->name = 'monei';
         $this->tab = 'payments_gateways';
-        $this->version = '2.0.11';
+        $this->version = '2.0.12';
         $this->author = 'MONEI';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '8', 'max' => _PS_VERSION_];

--- a/upgrade/upgrade-2.0.12.php
+++ b/upgrade/upgrade-2.0.12.php
@@ -1,0 +1,50 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Upgrade to 2.0.12 - Add missing is_captured column to monei2_payment table
+ */
+function upgrade_module_2_0_12($module)
+{
+    try {
+        // Check if the is_captured column exists
+        $sql = "SHOW COLUMNS FROM `" . _DB_PREFIX_ . "monei2_payment` LIKE 'is_captured'";
+        $result = Db::getInstance()->executeS($sql);
+
+        if (empty($result)) {
+            // Column doesn't exist, add it
+            $sql = "ALTER TABLE `" . _DB_PREFIX_ . "monei2_payment`
+                    ADD COLUMN `is_captured` TINYINT(1) DEFAULT 0 AFTER `status`";
+
+            if (!Db::getInstance()->execute($sql)) {
+                PrestaShopLogger::addLog(
+                    '[MONEI] Failed to add is_captured column during upgrade to 2.0.12',
+                    PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR
+                );
+                return false;
+            }
+
+            PrestaShopLogger::addLog(
+                '[MONEI] Successfully added is_captured column during upgrade to 2.0.12',
+                PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE
+            );
+        } else {
+            PrestaShopLogger::addLog(
+                '[MONEI] is_captured column already exists, skipping addition in upgrade to 2.0.12',
+                PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE
+            );
+        }
+
+        return true;
+    } catch (Exception $e) {
+        PrestaShopLogger::addLog(
+            '[MONEI] Upgrade to 2.0.12 failed: ' . $e->getMessage(),
+            PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR
+        );
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes SQL error that occurs when accessing payment records on upgraded installations
- Adds missing `is_captured` column via upgrade script
- Bumps version to 2.0.12

## Problem
The `is_captured` column was defined in the install script (`sql/install.php`) but was never added via an upgrade script for existing installations. This caused the following SQL error when trying to access payment records:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 't0.is_captured' in 'field list'
```

## Solution
- Created upgrade script `upgrade-2.0.12.php` that safely adds the missing column
- The script checks if the column already exists before attempting to add it
- Updated module version from 2.0.11 to 2.0.12

## Test plan
1. Install an older version of the module (< 2.0.12)
2. Upgrade to version 2.0.12
3. Verify the `is_captured` column is added to the `ps_monei2_payment` table
4. Test payment processing to ensure no SQL errors occur
5. Verify that running the upgrade multiple times doesn't cause issues (idempotent)