### PR TITLE
fix: exclude stray output.log from release ZIP (1.7.x)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         mkdir ../monei
         cp -r . ../monei/
         cd ..
-        zip -r monei.zip monei -x '*.git*' -x '/build/*'
+        zip -r monei.zip monei -x '*.git*' -x '/build/*' -x 'monei/output.log'
         
     - name: Upload Release
       uses: ncipollo/release-action@v1.14.0


### PR DESCRIPTION
## Summary

Excludes `output.log` (php-actions/composer build log) from the release ZIP on the 1.7.x release line.

## Why

`php-actions/composer@v6` writes `output.log` during the build step. `cp -r .` picks it up into the release dir and it ships in every release ZIP (2.4KB). Confirmed in 1.7.12 ZIP:

```
$ unzip -l monei.zip | grep output.log
     2406  10-01-2025 18:07   monei/output.log
```

Harmless functionally but confused a merchant debugging an install failure who reasonably assumed it was a relevant log.

Same fix is going into master via #98.

## Test plan

- [ ] Cut a test release on this branch and verify `monei.zip` no longer contains `monei/output.log`.

Refs #97